### PR TITLE
add(bq): Implement BigQuery impersonation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 # Go workspace file
 go.work
 /queries
+/tmp

--- a/pkg/cli/config/logger.go
+++ b/pkg/cli/config/logger.go
@@ -48,7 +48,7 @@ func (x *Logger) Flags() []cli.Flag {
 			Aliases:     []string{"o"},
 			EnvVars:     []string{"OVERSEER_LOG_OUTPUT"},
 			Usage:       "Set log output (create file other than '-', 'stdout', 'stderr')",
-			Value:       "stderr",
+			Value:       "stdout",
 			Destination: &x.output,
 		},
 	}

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -65,6 +65,10 @@ func runCommand() *cli.Command {
 				"sentry", sentry,
 			)
 
+			if err := sentry.Configure(); err != nil {
+				return err
+			}
+
 			queryFiles, err := listQueryFiles(taskDir)
 			if err != nil {
 				return err


### PR DESCRIPTION
Add `--bq-impersonate-service-account` option to specify impersonate service account