### PR TITLE
Add BigQuery config package

### DIFF
--- a/pkg/cli/config/bq/config.go
+++ b/pkg/cli/config/bq/config.go
@@ -23,14 +23,14 @@ func (x *Config) Flags() []cli.Flag {
 			Usage:       "BigQuery project ID",
 			Category:    "bq",
 			Destination: &x.projectID,
-			Sources:     cli.NewValueSourceChain(cli.EnvVar("OVERSEER_BQ_PROJECT_ID")),
+			Sources:     cli.NewValueSourceChain(cli.EnvVar("OVERSEER_BIGQUERY_PROJECT_ID")),
 		},
 		&cli.StringFlag{
 			Name:        "bq-impersonate-service-account",
 			Usage:       "Impersonate service account",
 			Category:    "bq",
 			Destination: &x.impersonateServiceAccount,
-			Sources:     cli.NewValueSourceChain(cli.EnvVar("OVERSEER_BQ_IMPERSONATE_SERVICE_ACCOUNT")),
+			Sources:     cli.NewValueSourceChain(cli.EnvVar("OVERSEER_BIGQUERY_IMPERSONATE_SERVICE_ACCOUNT")),
 		},
 	}
 }

--- a/pkg/cli/config/bq/config.go
+++ b/pkg/cli/config/bq/config.go
@@ -1,0 +1,77 @@
+package bq
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/m-mizutani/goerr"
+	"github.com/secmon-lab/overseer/pkg/adaptor/bq"
+	"github.com/urfave/cli/v3"
+	"google.golang.org/api/impersonate"
+	"google.golang.org/api/option"
+)
+
+type Config struct {
+	projectID                 string
+	impersonateServiceAccount string
+}
+
+func (x *Config) Flags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "bq-project-id",
+			Usage:       "BigQuery project ID",
+			Category:    "bq",
+			Destination: &x.projectID,
+			Sources:     cli.NewValueSourceChain(cli.EnvVar("OVERSEER_BQ_PROJECT_ID")),
+		},
+		&cli.StringFlag{
+			Name:        "bq-impersonate-service-account",
+			Usage:       "Impersonate service account",
+			Category:    "bq",
+			Destination: &x.impersonateServiceAccount,
+			Sources:     cli.NewValueSourceChain(cli.EnvVar("OVERSEER_BQ_IMPERSONATE_SERVICE_ACCOUNT")),
+		},
+	}
+}
+
+func (x *Config) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("bq-project-id", x.projectID),
+		slog.String("bq-impersonate-service-account", x.impersonateServiceAccount),
+	)
+}
+
+func (x *Config) ProjectID() string {
+	return x.projectID
+}
+
+func (x *Config) ImpersonateServiceAccount() string {
+	return x.impersonateServiceAccount
+}
+
+func (x *Config) Build(ctx context.Context) (*bq.Client, error) {
+	var bqOptions []option.ClientOption
+	if x.impersonateServiceAccount != "" {
+		ts, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+			TargetPrincipal: x.impersonateServiceAccount,
+			Scopes: []string{
+				"https://www.googleapis.com/auth/bigquery",
+				"https://www.googleapis.com/auth/cloud-platform",
+				"https://www.googleapis.com/auth/bigquery.readonly",
+				"https://www.googleapis.com/auth/cloud-platform.read-only",
+			},
+		})
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to create token source for impersonate")
+		}
+		bqOptions = append(bqOptions, option.WithTokenSource(ts))
+	}
+
+	bqClient, err := bq.New(ctx, x.projectID, bqOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return bqClient, nil
+}

--- a/pkg/cli/config/bq/config.go
+++ b/pkg/cli/config/bq/config.go
@@ -35,7 +35,7 @@ func (x *Config) Flags() []cli.Flag {
 	}
 }
 
-func (x *Config) LogValue() slog.Value {
+func (x Config) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("bq-project-id", x.projectID),
 		slog.String("bq-impersonate-service-account", x.impersonateServiceAccount),

--- a/pkg/cli/config/cache/config.go
+++ b/pkg/cli/config/cache/config.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/secmon-lab/overseer/pkg/adaptor/cs"
 	"github.com/secmon-lab/overseer/pkg/domain/interfaces"
@@ -45,6 +46,14 @@ func (x *Config) Flags() []cli.Flag {
 			Sources:     cli.NewValueSourceChain(cli.EnvVar("OVERSEER_GCS_PREFIX")),
 		},
 	}
+}
+
+func (x *Config) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("cache-dir", x.fsDir),
+		slog.String("cache-gcs-bucket", x.gcsBucket),
+		slog.String("cache-gcs-prefix", x.gcsPrefix),
+	)
 }
 
 func (x *Config) Build(ctx context.Context, id model.JobID) (interfaces.CacheService, error) {

--- a/pkg/cli/config/cache/config.go
+++ b/pkg/cli/config/cache/config.go
@@ -48,7 +48,7 @@ func (x *Config) Flags() []cli.Flag {
 	}
 }
 
-func (x *Config) LogValue() slog.Value {
+func (x Config) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("cache-dir", x.fsDir),
 		slog.String("cache-gcs-bucket", x.gcsBucket),

--- a/pkg/cli/config/notify/config.go
+++ b/pkg/cli/config/notify/config.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"io"
+	"log/slog"
 	"os"
 
 	"github.com/m-mizutani/goerr"
@@ -43,6 +44,14 @@ func (x *Config) Flags() []cli.Flag {
 			Destination: &x.output,
 		},
 	}
+}
+
+func (x *Config) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("notify-pubsub-topic", x.pubsubTopic),
+		slog.String("notify-pubsub-project", x.pubsubProject),
+		slog.String("notify-out", x.output),
+	)
 }
 
 func (x *Config) Build() (interfaces.NotifyService, error) {

--- a/pkg/cli/config/notify/config.go
+++ b/pkg/cli/config/notify/config.go
@@ -46,7 +46,7 @@ func (x *Config) Flags() []cli.Flag {
 	}
 }
 
-func (x *Config) LogValue() slog.Value {
+func (x Config) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("notify-pubsub-topic", x.pubsubTopic),
 		slog.String("notify-pubsub-project", x.pubsubProject),

--- a/pkg/cli/config/policy/cfg.go
+++ b/pkg/cli/config/policy/cfg.go
@@ -1,6 +1,8 @@
 package policy
 
 import (
+	"log/slog"
+
 	"github.com/m-mizutani/goerr"
 	"github.com/m-mizutani/opac"
 	"github.com/secmon-lab/overseer/pkg/domain/model"
@@ -36,6 +38,13 @@ func (x *Config) Flags() []cli.Flag {
 
 func (x *Config) FilePath() []string {
 	return x.filePath[:]
+}
+
+func (x *Config) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Any("policy", x.filePath),
+		slog.Any("tag", x.selectTags),
+	)
 }
 
 func (x *Config) Build() (*service.Policy, error) {

--- a/pkg/cli/config/policy/cfg.go
+++ b/pkg/cli/config/policy/cfg.go
@@ -40,7 +40,7 @@ func (x *Config) FilePath() []string {
 	return x.filePath[:]
 }
 
-func (x *Config) LogValue() slog.Value {
+func (x Config) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.Any("policy", x.filePath),
 		slog.Any("tag", x.selectTags),

--- a/pkg/cli/config/query/cfg.go
+++ b/pkg/cli/config/query/cfg.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +37,12 @@ func (x *Config) Flags() []cli.Flag {
 			Aliases:     []string{"q"},
 		},
 	}
+}
+
+func (x *Config) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Any("query", x.filePath),
+	)
 }
 
 func (x *Config) Build() (model.Queries, error) {

--- a/pkg/cli/config/query/cfg.go
+++ b/pkg/cli/config/query/cfg.go
@@ -39,7 +39,7 @@ func (x *Config) Flags() []cli.Flag {
 	}
 }
 
-func (x *Config) LogValue() slog.Value {
+func (x Config) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.Any("query", x.filePath),
 	)

--- a/pkg/cli/eval.go
+++ b/pkg/cli/eval.go
@@ -37,7 +37,9 @@ func cmdEval() *cli.Command {
 	flags = append(flags, notifyCfg.Flags()...)
 
 	action := func(ctx context.Context, c *cli.Command) error {
-		ctx = logging.InjectCtx(ctx, logging.Default().With("job_id", jobID))
+		logger := logging.Default().With("job_id", jobID)
+		ctx = logging.InjectCtx(ctx, logger)
+		logger.Info("Start overseer", "policy", policyCfg, "cache", cacheCfg, "notify", notifyCfg)
 
 		cacheSvc, err := cacheCfg.Build(ctx, jobID)
 		if err != nil {

--- a/pkg/cli/eval.go
+++ b/pkg/cli/eval.go
@@ -39,7 +39,11 @@ func cmdEval() *cli.Command {
 	action := func(ctx context.Context, c *cli.Command) error {
 		logger := logging.Default().With("job_id", jobID)
 		ctx = logging.InjectCtx(ctx, logger)
-		logger.Info("Start overseer", "policy", policyCfg, "cache", cacheCfg, "notify", notifyCfg)
+		logger.Info("Start overseer",
+			"policy", policyCfg,
+			"cache", cacheCfg,
+			"notify", notifyCfg,
+		)
 
 		cacheSvc, err := cacheCfg.Build(ctx, jobID)
 		if err != nil {

--- a/pkg/cli/fetch.go
+++ b/pkg/cli/fetch.go
@@ -3,9 +3,8 @@ package cli
 import (
 	"context"
 
-	"github.com/m-mizutani/goerr"
 	"github.com/secmon-lab/overseer/pkg/adaptor"
-	"github.com/secmon-lab/overseer/pkg/adaptor/bq"
+	"github.com/secmon-lab/overseer/pkg/cli/config/bq"
 	"github.com/secmon-lab/overseer/pkg/cli/config/cache"
 	"github.com/secmon-lab/overseer/pkg/cli/config/policy"
 	"github.com/secmon-lab/overseer/pkg/cli/config/query"
@@ -13,43 +12,28 @@ import (
 	"github.com/secmon-lab/overseer/pkg/logging"
 	"github.com/secmon-lab/overseer/pkg/usecase"
 	"github.com/urfave/cli/v3"
-	"google.golang.org/api/impersonate"
-	"google.golang.org/api/option"
 )
 
 func cmdFetch() *cli.Command {
 	var (
-		queryCfg                    query.Config
-		policyCfg                   policy.Config
-		cacheCfg                    cache.Config
-		bqProjectID                 string
-		bqImpersonateServiceAccount string
+		queryCfg  query.Config
+		policyCfg policy.Config
+		cacheCfg  cache.Config
+		bqCfg     bq.Config
 	)
 
-	flags := []cli.Flag{
-		&cli.StringFlag{
-			Name:        "bigquery-project-id",
-			Usage:       "BigQuery project ID",
-			Category:    "fetch",
-			Destination: &bqProjectID,
-			Sources:     cli.NewValueSourceChain(cli.EnvVar("OVERSEER_BIGQUERY_PROJECT_ID")),
-			Required:    true,
-		},
-		&cli.StringFlag{
-			Name:        "bigquery-impersonate-service-account",
-			Usage:       "Impersonate service account for BigQuery",
-			Category:    "fetch",
-			Destination: &bqImpersonateServiceAccount,
-			Sources:     cli.NewValueSourceChain(cli.EnvVar("OVERSEER_BIGQUERY_IMPERSONATE_SERVICE_ACCOUNT")),
-		},
-	}
+	flags := []cli.Flag{}
 	flags = append(flags, queryCfg.Flags()...)
 	flags = append(flags, policyCfg.Flags()...)
 	flags = append(flags, cacheCfg.Flags()...)
+	flags = append(flags, bqCfg.Flags()...)
 
 	action := func(ctx context.Context, c *cli.Command) error {
 		id := model.NewJobID()
-		ctx = logging.InjectCtx(ctx, logging.Default().With("job_id", id))
+
+		logger := logging.Default().With("job_id", id)
+		ctx = logging.InjectCtx(ctx, logger)
+		logger.Info("Start overseer", "query", queryCfg, "policy", policyCfg, "cache", cacheCfg, "bq", bqCfg)
 
 		cacheSvc, err := cacheCfg.Build(ctx, id)
 		if err != nil {
@@ -61,24 +45,7 @@ func cmdFetch() *cli.Command {
 			return err
 		}
 
-		var bqOptions []option.ClientOption
-		if bqImpersonateServiceAccount != "" {
-			ts, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
-				TargetPrincipal: bqImpersonateServiceAccount,
-				Scopes: []string{
-					"https://www.googleapis.com/auth/bigquery",
-					"https://www.googleapis.com/auth/cloud-platform",
-					"https://www.googleapis.com/auth/bigquery.readonly",
-					"https://www.googleapis.com/auth/cloud-platform.read-only",
-				},
-			})
-			if err != nil {
-				return goerr.Wrap(err, "failed to create token source for impersonate")
-			}
-			bqOptions = append(bqOptions, option.WithTokenSource(ts))
-		}
-
-		bqClient, err := bq.New(ctx, bqProjectID, bqOptions...)
+		bqClient, err := bqCfg.Build(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/m-mizutani/goerr"
 	"github.com/secmon-lab/overseer/pkg/adaptor"
-	"github.com/secmon-lab/overseer/pkg/adaptor/bq"
+	"github.com/secmon-lab/overseer/pkg/cli/config/bq"
 	"github.com/secmon-lab/overseer/pkg/cli/config/cache"
 	"github.com/secmon-lab/overseer/pkg/cli/config/notify"
 	"github.com/secmon-lab/overseer/pkg/cli/config/policy"
@@ -18,31 +18,26 @@ import (
 
 func cmdRun() *cli.Command {
 	var (
-		queryCfg    query.Config
-		policyCfg   policy.Config
-		cacheCfg    cache.Config
-		notifyCfg   notify.Config
-		bqProjectID string
+		queryCfg  query.Config
+		policyCfg policy.Config
+		cacheCfg  cache.Config
+		notifyCfg notify.Config
+		bqCfg     bq.Config
 	)
 
-	flags := []cli.Flag{
-		&cli.StringFlag{
-			Name:        "bigquery-project-id",
-			Usage:       "BigQuery project ID",
-			Category:    "fetch",
-			Destination: &bqProjectID,
-			Sources:     cli.NewValueSourceChain(cli.EnvVar("OVERSEER_BIGQUERY_PROJECT_ID")),
-			Required:    true,
-		},
-	}
+	flags := []cli.Flag{}
 	flags = append(flags, queryCfg.Flags()...)
 	flags = append(flags, policyCfg.Flags()...)
 	flags = append(flags, cacheCfg.Flags()...)
 	flags = append(flags, notifyCfg.Flags()...)
+	flags = append(flags, bqCfg.Flags()...)
 
 	action := func(ctx context.Context, c *cli.Command) error {
 		id := model.NewJobID()
-		ctx = logging.InjectCtx(ctx, logging.Default().With("job_id", id))
+
+		logger := logging.Default().With("job_id", id)
+		ctx = logging.InjectCtx(ctx, logger)
+		logger.Info("Start overseer", "query", queryCfg, "policy", policyCfg, "cache", cacheCfg, "notify", notifyCfg, "bq", bqCfg)
 
 		cacheSvc, err := cacheCfg.Build(ctx, id)
 		if err != nil {
@@ -67,7 +62,7 @@ func cmdRun() *cli.Command {
 			return err
 		}
 
-		bqClient, err := bq.New(ctx, bqProjectID)
+		bqClient, err := bqCfg.Build(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/service/notify.go
+++ b/pkg/service/notify.go
@@ -16,7 +16,7 @@ type NotifyPubSub struct {
 }
 
 func NewNotifyPubSub(client interfaces.PubSubClient, topic string) *NotifyPubSub {
-	return &NotifyPubSub{client: client}
+	return &NotifyPubSub{client: client, topic: topic}
 }
 
 func (x *NotifyPubSub) Publish(ctx context.Context, alert model.Alert) error {


### PR DESCRIPTION
This pull request introduces logging enhancements and refactors BigQuery configuration handling across various packages. The most important changes include adding logging capabilities to configuration files and refactoring BigQuery configuration to a dedicated package.

Logging enhancements:
* [`pkg/cli/config/cache/config.go`](diffhunk://#diff-bb31230b4408d9ce54de7e20476b91f4b16ee6fcb40b3faba8dc58b2846a323bR51-R58): Added `LogValue` method to log cache configuration details.
* [`pkg/cli/config/notify/config.go`](diffhunk://#diff-44c3255f2c8d7d23749e4ef2b8fda8f44a9a35fb47d64b72ecf8b034821f55eaR49-R56): Added `LogValue` method to log notification configuration details.
* [`pkg/cli/config/policy/cfg.go`](diffhunk://#diff-3c1a7de8ceecb9536ca84ad650b339914ce7b5aff77e025faa4b253e7afd0b0dR43-R49): Added `LogValue` method to log policy configuration details.
* [`pkg/cli/config/query/cfg.go`](diffhunk://#diff-8f700beade6dc9cc37dd3d84f3133a8a726a89e1f3e13009cb2cd0d78a8fe187R42-R47): Added `LogValue` method to log query configuration details.

BigQuery configuration refactor:
* [`pkg/cli/config/bq/config.go`](diffhunk://#diff-fd7a1dfd7b062f531b63b945fba41bcc96ed177f04e43c97b92c94cbbae10ff9R1-R77): Introduced a new `Config` struct to handle BigQuery configuration, including project ID and impersonation service account.
* `pkg/cli/fetch.go` and `pkg/cli/run.go`: Refactored to use the new `bq.Config` for BigQuery configuration, replacing inline configurations. [[1]](diffhunk://#diff-2d5081c98aab58729f425073b1e3800f65dd7595058e12026a4910f6e68863dcL6-R36) [[2]](diffhunk://#diff-47f2d9967f1f75f8c014037b08722883d56a0024589ba28a44842193fecf651bL8-R8)