### PR TITLE
Enhance/job id ctx

### DIFF
--- a/pkg/cli/fetch.go
+++ b/pkg/cli/fetch.go
@@ -29,7 +29,7 @@ func cmdFetch() *cli.Command {
 	flags = append(flags, bqCfg.Flags()...)
 
 	action := func(ctx context.Context, c *cli.Command) error {
-		id := model.NewJobID()
+		ctx, id := model.NewJobID(ctx)
 
 		logger := logging.Default().With("job_id", id)
 		ctx = logging.InjectCtx(ctx, logger)

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -33,7 +33,7 @@ func cmdRun() *cli.Command {
 	flags = append(flags, bqCfg.Flags()...)
 
 	action := func(ctx context.Context, c *cli.Command) error {
-		id := model.NewJobID()
+		ctx, id := model.NewJobID(ctx)
 
 		logger := logging.Default().With("job_id", id)
 		ctx = logging.InjectCtx(ctx, logger)

--- a/pkg/domain/model/alert.go
+++ b/pkg/domain/model/alert.go
@@ -87,6 +87,7 @@ func NewAlert(ctx context.Context, body AlertBody) (*Alert, error) {
 	x := &Alert{
 		ID:        NewAlertID(),
 		Version:   AlertSchemaVersion,
+		JobID:     JobIDFromCtx(ctx),
 		Timestamp: ts,
 
 		AlertBody: body,

--- a/pkg/domain/model/job.go
+++ b/pkg/domain/model/job.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -9,8 +10,9 @@ import (
 )
 
 type JobID string
+type ctxJobIDKeyType struct{}
 
-func NewJobID() JobID {
+func NewJobID(ctx context.Context) (context.Context, JobID) {
 	id, err := uuid.NewV7()
 	if err != nil {
 		logging.Default().Error("fail to generate new JobID", "err", err)
@@ -18,5 +20,13 @@ func NewJobID() JobID {
 	}
 
 	now := time.Now()
-	return JobID(now.Format("job200601021504_") + strings.ReplaceAll(id.String(), "-", ""))
+	jobID := JobID(now.Format("job200601021504_") + strings.ReplaceAll(id.String(), "-", ""))
+	return context.WithValue(ctx, ctxJobIDKeyType{}, jobID), jobID
+}
+
+func JobIDFromCtx(ctx context.Context) JobID {
+	if id, ok := ctx.Value(ctxJobIDKeyType{}).(JobID); ok {
+		return id
+	}
+	return ""
 }

--- a/pkg/service/cache_test.go
+++ b/pkg/service/cache_test.go
@@ -15,7 +15,9 @@ import (
 
 func TestCacheFile(t *testing.T) {
 	d := os.TempDir()
-	id1, id2 := model.NewJobID(), model.NewJobID()
+	ctx := context.Background()
+	_, id1 := model.NewJobID(ctx)
+	_, id2 := model.NewJobID(ctx)
 	svc1, err := service.NewFileCache(id1, d)
 	gt.NoError(t, err)
 	svc2, err := service.NewFileCache(id2, d)
@@ -26,7 +28,11 @@ func TestCacheFile(t *testing.T) {
 
 func TestCacheFileGzip(t *testing.T) {
 	d := os.TempDir()
-	id1, id2 := model.NewJobID(), model.NewJobID()
+
+	ctx := context.Background()
+	_, id1 := model.NewJobID(ctx)
+	_, id2 := model.NewJobID(ctx)
+
 	svc1, err := service.NewFileCache(id1, d, service.WithGzip())
 	gt.NoError(t, err)
 	svc2, err := service.NewFileCache(id2, d, service.WithGzip())
@@ -43,7 +49,10 @@ func TestCacheCloudStorage(t *testing.T) {
 
 	client, err := cs.NewClient(context.Background())
 
-	id1, id2 := model.NewJobID(), model.NewJobID()
+	ctx := context.Background()
+	_, id1 := model.NewJobID(ctx)
+	_, id2 := model.NewJobID(ctx)
+
 	svc1 := service.NewCloudStorageCache(id1, bucketName, "overseer-test", client)
 	gt.NoError(t, err)
 	svc2 := service.NewCloudStorageCache(id2, bucketName, "overseer-test", client)
@@ -60,7 +69,10 @@ func TestCacheCloudStorageGzip(t *testing.T) {
 
 	client, err := cs.NewClient(context.Background())
 
-	id1, id2 := model.NewJobID(), model.NewJobID()
+	ctx := context.Background()
+	_, id1 := model.NewJobID(ctx)
+	_, id2 := model.NewJobID(ctx)
+
 	svc1 := service.NewCloudStorageCache(id1, bucketName, "overseer-test", client, service.WithGzip())
 	gt.NoError(t, err)
 	svc2 := service.NewCloudStorageCache(id2, bucketName, "overseer-test", client, service.WithGzip())


### PR DESCRIPTION
This pull request introduces changes to improve the handling of `JobID` by passing it through the context. The primary modifications include updating the `NewJobID` function to return a context with the `JobID`, and adjusting various parts of the codebase to accommodate this change.

### Contextual `JobID` Handling:

* [`pkg/domain/model/job.go`](diffhunk://#diff-299b13a3dd8626fc4167cc08e74e2f2c4f60acf44bf08c72b6d38562d2a9b012R4): Updated `NewJobID` to return a context with the `JobID` and added `JobIDFromCtx` to retrieve the `JobID` from the context. [[1]](diffhunk://#diff-299b13a3dd8626fc4167cc08e74e2f2c4f60acf44bf08c72b6d38562d2a9b012R4) [[2]](diffhunk://#diff-299b13a3dd8626fc4167cc08e74e2f2c4f60acf44bf08c72b6d38562d2a9b012R13-R31)
* [`pkg/domain/model/alert.go`](diffhunk://#diff-8d7503848567acc5ba5f287a31882b2e4c0fb21a8d6318b304c9a93ac83a8bb6R90): Modified `NewAlert` to extract the `JobID` from the context.

### Command Functions:

* [`pkg/cli/fetch.go`](diffhunk://#diff-2d5081c98aab58729f425073b1e3800f65dd7595058e12026a4910f6e68863dcL32-R32): Updated `cmdFetch` to use the new `NewJobID` function that returns a context.
* [`pkg/cli/run.go`](diffhunk://#diff-47f2d9967f1f75f8c014037b08722883d56a0024589ba28a44842193fecf651bL36-R36): Updated `cmdRun` to use the new `NewJobID` function that returns a context.

### Test Updates:

* [`pkg/service/cache_test.go`](diffhunk://#diff-0007e3d91c01ee6ad477de424272eb93ccd597c83bc50e2dde80888804147859L18-R20): Adjusted test functions to use the new `NewJobID` function that returns a context. [[1]](diffhunk://#diff-0007e3d91c01ee6ad477de424272eb93ccd597c83bc50e2dde80888804147859L18-R20) [[2]](diffhunk://#diff-0007e3d91c01ee6ad477de424272eb93ccd597c83bc50e2dde80888804147859L29-R35) [[3]](diffhunk://#diff-0007e3d91c01ee6ad477de424272eb93ccd597c83bc50e2dde80888804147859L46-R55) [[4]](diffhunk://#diff-0007e3d91c01ee6ad477de424272eb93ccd597c83bc50e2dde80888804147859L63-R75)