### PR TITLE
Add rule ID

### DIFF
--- a/pkg/domain/model/alert.go
+++ b/pkg/domain/model/alert.go
@@ -43,6 +43,9 @@ type Alert struct {
 
 // AlertBody is a body of Alert. It contains title, description, timestamp and additional attributes.
 type AlertBody struct {
+	// RuleID is identifier of rule that generates alert. It's optional.
+	RuleID string `json:"rule_id"`
+
 	// Title is short description of alert. It's required.
 	Title string `json:"title"`
 

--- a/pkg/usecase/eval_test.go
+++ b/pkg/usecase/eval_test.go
@@ -44,6 +44,8 @@ func TestEval(t *testing.T) {
 	}
 	notify := &mock.NotifyServiceMock{
 		PublishFunc: func(ctx context.Context, alert model.Alert) error {
+			gt.EQ(t, alert.RuleID, "test_policy1")
+			gt.EQ(t, alert.Version, "v0")
 			gt.EQ(t, alert.Title, "Test Policy 1")
 			gt.EQ(t, alert.Description, "Principal attempted to access data")
 			gt.True(t, alert.Timestamp.Equal(time.Date(2021, 3, 1, 0, 0, 0, 0, time.UTC)))

--- a/pkg/usecase/testdata/eval/policy1.rego
+++ b/pkg/usecase/testdata/eval/policy1.rego
@@ -9,6 +9,7 @@ package test_policy1
 import rego.v1
 
 alert contains {
+    "rule_id": "test_policy1",
     "title": "Test Policy 1",
     "description": "Principal attempted to access data",
     "timestamp": r.latest,


### PR DESCRIPTION
This pull request includes several changes to the alert system, primarily focusing on adding and testing the `RuleID` field in alerts. The most important changes include the addition of the `RuleID` field to the `AlertBody` struct, updates to test cases to verify this new field, and modifications to the policy file to include the `RuleID`.

### Enhancements to Alert System:

* [`pkg/domain/model/alert.go`](diffhunk://#diff-8d7503848567acc5ba5f287a31882b2e4c0fb21a8d6318b304c9a93ac83a8bb6R46-R48): Added the `RuleID` field to the `AlertBody` struct to identify the rule that generates the alert.
* [`pkg/usecase/eval_test.go`](diffhunk://#diff-10659ffeed8e1251f2a70f08c925c68dfae28ff4194e5a02d26e3103463eda5cR47-R48): Updated test cases to verify the `RuleID` field in the alert. This ensures that the `RuleID` is correctly set and retrieved during testing.
* [`pkg/usecase/testdata/eval/policy1.rego`](diffhunk://#diff-961ce7ce24e22e2b931ff681b49e2ed7762df1198b6b042dc251774e4b45cbcbR12): Modified the policy file to include the `RuleID` field in the alert, setting it to "test_policy1".